### PR TITLE
Multiple fixes

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -3,8 +3,8 @@ function HandleDisguiseCommand(Split, Player)
 		Player:SendMessageInfo("Usage: "..Split[1].." <mobtype[:baby]> [customname ...]")
 		Player:SendMessageInfo("Available types: bat, blaze, cavespider, chicken, cow, creeper, enderdragon, enderman, ghast, giant, guardian, horse, irongolem, magmacube, mooshroom, ocelot, pig, rabbit, sheep, silverfish, skeleton, slime, snowgolem, spider, squid, villager, witch, wither, wolf, zombie, zombiepigman")
 	else
-		IsBaby = false
-		MobString = Split[2]
+		local IsBaby = false
+		local MobString = Split[2]
 		
 		if string.find(MobString, ":") then
 			MobString, data = string.match(MobString, "(%w+):(%w+)")
@@ -13,7 +13,7 @@ function HandleDisguiseCommand(Split, Player)
 			end
 		end
 
-		MobType = cMonster:StringToMobType(MobString)
+		local MobType = cMonster:StringToMobType(MobString)
 
 		if MobType == mtInvalidType then
 			Player:SendMessageFailure("That disguise type was not recognized")
@@ -28,8 +28,6 @@ function HandleDisguiseCommand(Split, Player)
 				mobid[Player:GetName()],
 				function(MobFunctions)
 					SetMobFunction = tolua.cast(MobFunctions, "cMonster")
-					SetMobFunction:SetMaxHealth(999999)
-					SetMobFunction:SetHealth(999999)
 					SetMobFunction:SetCustomName(table.concat( Split , " " , 3 ))
 				end
 			)

--- a/hooks.lua
+++ b/hooks.lua
@@ -1,20 +1,21 @@
 function OnWorldTick(World, TimeDelta)
 	local MoveMob = function(Entity)
 		local Monster = tolua.cast(Entity,"cMonster")
-		Monster:TeleportToCoords(PlayerID:GetPosX(), PlayerID:GetPosY(), PlayerID:GetPosZ())
-		Monster:MoveToPosition(PlayerID:GetPosition() + PlayerID:GetLookVector())
-		if Monster:GetHealth() == 0 then
-			PlayerID:SendMessageWarning("Your mob is dead, you've been undisguised")
-			PlayerID:SetVisible(true)
-			Monster:Destroy()
-			mobid[Player:GetName()] = nil
-		end
+		Monster:TeleportToCoords(PlayerID:GetPosX() + 1, PlayerID:GetPosY(), PlayerID:GetPosZ() + 1)
+		Monster:SetSpeed(0,0,0)
+		Monster:SetMaxHealth(99999)
+		Monster:SetHealth(99999)
 	end
 	local Player = function(Player)
 		PlayerID = Player
 		local entityId = mobid[Player:GetName()];
 		if entityId ~= nil then
 			World:DoWithEntityByID(mobid[Player:GetName()], MoveMob)
+		end
+		if Player:IsVisible() == true and entityId ~= nil then
+			Player:SendMessageInfo("You have been undisguised due to your visibility being set to true")
+			World:DoWithEntityByID(mobid[Player:GetName()], cEntity.Destroy)
+			mobid[Player:GetName()] = nil
 		end
 	end
 	World:ForEachPlayer(Player)
@@ -36,11 +37,18 @@ function OnTakeDamage(Receiver, TDI)
 			return true
 		end
 	end
-end    
+end
+
+function OnPlayerSpawned(Player)
+	if mobid[Player:GetName()] ~= nil then
+		Player:SetVisible(false)
+	end
+end
 
 function OnPlayerDestroyed(Player)
 	if mobid[Player:GetName()] ~= nil then
 		Player:GetWorld():DoWithEntityByID(mobid[Player:GetName()], cEntity.Destroy)
 		Player:SetVisible(true)
+		mobid[Player:GetName()] = nil
 	end
-end    
+end

--- a/main.lua
+++ b/main.lua
@@ -7,9 +7,10 @@ function Initialize(Plugin)
 	Plugin:SetName(g_PluginInfo.Name)
 	Plugin:SetVersion(g_PluginInfo.Version)
 
-	cPluginManager.AddHook(cPluginManager.HOOK_WORLD_TICK, OnWorldTick)
-	cPluginManager:AddHook(cPluginManager.HOOK_TAKE_DAMAGE, OnTakeDamage);
-	cPluginManager:AddHook(cPluginManager.HOOK_PLAYER_DESTROYED, OnPlayerDestroyed);
+	cPluginManager:AddHook(cPluginManager.HOOK_WORLD_TICK, OnWorldTick)
+	cPluginManager:AddHook(cPluginManager.HOOK_TAKE_DAMAGE, OnTakeDamage)
+	cPluginManager:AddHook(cPluginManager.HOOK_PLAYER_SPAWNED, OnPlayerSpawned)
+	cPluginManager:AddHook(cPluginManager.HOOK_PLAYER_DESTROYED, OnPlayerDestroyed)
 
 	RegisterPluginInfoCommands();
 
@@ -21,7 +22,7 @@ function OnDisable()
 	local RemoveMob = function(Player)
 		if mobid[Player:GetName()] ~= nil then
 			Player:GetWorld():DoWithEntityByID(mobid[Player:GetName()], cEntity.Destroy)
-			Player:SendMessageWarning("You've been undisguised because of server restart/reload")
+			Player:SendMessageWarning("You've been undisguised due to server reload")
 			Player:SetVisible(true)
 		end
 	end    


### PR DESCRIPTION
- If disguised when respawning, your visibility is set to false
- Set a disguised mob's moving speed to 0, to prevent it from freaking out and teleporting
- A player's disguise status is set to undisguised when leaving the server

(For some reason mobs look backwards when a player moves forward. I think this is a bug in the server code, since Ender Dragons look forward.)